### PR TITLE
DEV: Add heading to custom gitignore section

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -222,6 +222,11 @@ Network Trash Folder
 Temporary Items
 .apdisk
 
+
+##---------------------------------------------------
+# Custom .gitignore
+##---------------------------------------------------
+
 # Program output directories
 outputs
 query-outputs*


### PR DESCRIPTION
Minor PR to add a section heading to the .gitignore file, so it doesn't look like our custom ignore list is part of the Mac OSX default ignores.