### PR TITLE
Change the way datasets are saved

### DIFF
--- a/pangaea_downloader/pq_scraper.py
+++ b/pangaea_downloader/pq_scraper.py
@@ -57,7 +57,7 @@ def search_and_download(query=None, output_dir="query-outputs", verbose=1):
         # ------------- ASSESS DATASET TYPE ------------- #
         df = None
         if is_parent:
-            df = datasets.fetch_children(url)
+            datasets.fetch_children(url, output_dir)
         else:
             dataset_type = process.ds_type(size)
             if dataset_type == "video":

--- a/pangaea_downloader/tools/datasets.py
+++ b/pangaea_downloader/tools/datasets.py
@@ -8,7 +8,7 @@ Note: this module is only for Parent and Child datasets.
 import os
 from typing import Optional
 
-from pandas import DataFrame, concat
+from pandas import DataFrame
 from pangaeapy import PanDataSet
 
 from pangaea_downloader.tools import checker, process, scraper
@@ -32,8 +32,8 @@ def fetch_child(child_url: str) -> Optional[DataFrame]:
     return df
 
 
-def fetch_children(parent_url: str) -> Optional[DataFrame]:
-    """Take in url of a parent dataset, fetch and return merged child datasets."""
+def fetch_children(parent_url: str, out_dir: str):
+    """Take in url of a parent dataset and output directory path, fetch and save child datasets to file."""
     # Fetch dataset
     ds = PanDataSet(parent_url)
     # Check restriction
@@ -42,7 +42,6 @@ def fetch_children(parent_url: str) -> Optional[DataFrame]:
         return
     # Process children
     print(f"\t[INFO] Fetching {len(ds.children)} child datasets...")
-    df_list = []
     for i, child_uri in enumerate(ds.children):
         url = process.url_from_uri(child_uri)
         size = process.get_html_info(url)
@@ -54,7 +53,9 @@ def fetch_children(parent_url: str) -> Optional[DataFrame]:
         elif typ == "paginated":
             print(f"\t\t[{i+1}] Scrapping dataset...")
             df = scraper.scrape_image_data(url)
-            df_list.append(df)
+            child = PanDataSet(url)
+            # Save scrapped dataset
+            save_df(df, child.id, out_dir)
         elif typ == "tabular":
             child = PanDataSet(url)
             if ds.loginstatus != "unrestricted":
@@ -70,18 +71,8 @@ def fetch_children(parent_url: str) -> Optional[DataFrame]:
                 # Add metadata
                 child_doi = child.doi.split("doi.org/")[-1]
                 df = set_metadata(child, alt=child_doi)
-                # Add child dataset to list
-                df_list.append(df)
-
-    # Return result
-    if len(df_list) <= 0:
-        # Empty list
-        print("\t[ERROR] No child dataset had image URL column!")
-        return None
-    else:
-        # List NOT empty
-        print("\t[INFO] Joining child datasets...")
-        return concat(df_list, ignore_index=True)
+                # Save child dataset
+                save_df(df, child.id, out_dir)
 
 
 def set_metadata(ds: PanDataSet, alt="unknown") -> DataFrame:
@@ -105,4 +96,4 @@ def save_df(df: DataFrame, ds_id: str, output_dir: str):
     f_name = ds_id + ".csv"
     path = os.path.join(output_dir, f_name)
     df.to_csv(path, index=False)
-    print(f"\t[INFO] Saved to '{path}'")
+    print(f"\t\t[INFO] Saved to '{path}'")


### PR DESCRIPTION
Save each of the children of a parent dataset as separate files instead of merging together and saving as one file. The reason for this is because in some datasets there are multiple columns with the same name.

For example a dataset with columns: [ id, lat, lon, url, coral, coral, moss, moss ]. In this case, the first coral column shows the % coverage of coral in the image, which the second coral column shows the  % coverage of bleached coral. 

Naming two or more columns with the same name is problematic. Even more so when there are multiple datasets with the same column names. In some cases a parent dataset may have multiple children having the same column names occurring two or more times in their dataframes. eg:
[ id, lat, lon, url, coral, coral, moss, moss ... ]
[ id, lat, lon, url, filename, station, coral, coral, litter … ]
…
Merging such datasets may be problematic, since we don't know just from the column names which one represents what kind of data.
