### PR TITLE
Change method of saving dataframes

### DIFF
--- a/pangaea_downloader/pq_scraper.py
+++ b/pangaea_downloader/pq_scraper.py
@@ -74,9 +74,9 @@ def search_and_download(query=None, output_dir="query-outputs", verbose=1):
             datasets.save_df(df, ds_id, output_dir, level=1)
             n_downloads += 1
         if df_list is not None:
-            for child in df_list:
+            for ch_i, child in enumerate(df_list):
                 child_id = child["DOI"].iloc[0].split(".")[-1]
-                datasets.save_df(child, child_id, output_dir, level=2)
+                datasets.save_df(child, child_id, output_dir, level=2, index=ch_i + 1)
                 n_downloads += 1
 
     print(f"Complete! Total files downloaded: {n_downloads}.")

--- a/pangaea_downloader/tools/datasets.py
+++ b/pangaea_downloader/tools/datasets.py
@@ -98,10 +98,11 @@ def set_metadata(ds: PanDataSet, alt="unknown") -> DataFrame:
     return ds.data
 
 
-def save_df(df: DataFrame, ds_id: str, output_dir: str, level=1):
+def save_df(df: DataFrame, ds_id: str, output_dir: str, level=1, index=None):
     """Save a DataFrame to file in a provided output directory."""
     f_name = ds_id + ".csv"
     path = os.path.join(output_dir, f_name)
     df.to_csv(path, index=False)
     tabs = "\t\t" if level == 2 else "\t"
-    print(f"{tabs}[INFO] Saved to '{path}'")
+    idx = "INFO" if index is None else index
+    print(f"{tabs}[{idx}] Saved to '{path}'")


### PR DESCRIPTION
In a previous commit, I changed the way the children of parent datasets were being saved. At first, the child datasets would be merged together in one data frame and save to one file. This last commit changed this, saving each child in separate files from within the `fetch_children` function.

Although saving children in separate files in a good change (reasons mentioned in pull request #16), saving them from within the `fetch_children` function can have some issues. In the `search_and_download` function, we are counting the number of files downloaded. If we save the files from within the imported `fetch_children` function it doesn't update the count resulting in incorrect info.

So, in this branch I am returning the fetched child datasets as a list and saving each file from that list in the main program.