### PR TITLE
ENH: Rate-limit download requests to once every 0.167 seconds

### DIFF
--- a/pangaea_downloader/tools/scraper.py
+++ b/pangaea_downloader/tools/scraper.py
@@ -1,4 +1,5 @@
 """Functions for scraping image urls and metadata from paginated datasets."""
+import time
 from typing import List, Optional, Tuple
 
 import requests
@@ -13,7 +14,10 @@ import pangaea_downloader.tools.datasets as datasets
 def scrape_image_data(url: str) -> Optional[DataFrame]:
     """Scrape image URLs and metadata from webpage(s)."""
     # Load dataset
+    t_wait = max(0, datasets.T_POLL_LAST + datasets.T_POLL_INTV - time.time())
+    time.sleep(t_wait)  # Stay under 180 requests every 30s
     ds = PanDataSet(url)
+    datasets.T_POLL_LAST = time.time()
     # Request dataset url
     print("\t\t\t[INFO] Requesting:", url)
     resp = requests.get(url)


### PR DESCRIPTION
The request rate which pangaea will serve is rate limited to a maximum of 180 per 30s for each client connecting to it. If we exceed this, we get a HTTP 403 error. The error message passed on from pangaeapy reads:

> You started too many requests per time interval to this web application. A client is only allowed to start a maximum of 180 requests per 30s to this service. Please try again later!

Here, we throttle ourselves to prevent this error from arising.