### PR TITLE
JNB: Cov dataset

### DIFF
--- a/notebooks/column_mapping.ipynb
+++ b/notebooks/column_mapping.ipynb
@@ -1310,6 +1310,80 @@
     "    index=False,\n",
     ")"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e9d32e61-1efc-488b-bd53-4d3d4d3b8ed0",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b10ff34d-71fa-461b-88b0-be5c1145032f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cov_dfs = []\n",
+    "for fname in tqdm(coverage_datasets):\n",
+    "    ds_id = os.path.splitext(fname)[0]\n",
+    "    df = pd.read_csv(os.path.join(dirname, fname))\n",
+    "    if not checker.has_url_col(df):\n",
+    "        continue\n",
+    "    # print(df.columns)\n",
+    "    url_col = find_url_column(df)\n",
+    "    if not url_col:\n",
+    "        print(f\"No url column for {fname} with columns\\n{df.columns}\")\n",
+    "        continue\n",
+    "    df[\"ds_id\"] = f\"pangaea-{ds_id}\"\n",
+    "    df = reformat_df(df, remove_duplicate_columns=False)\n",
+    "    if df is None or len(df) == 0:\n",
+    "        continue\n",
+    "    df = df[~df[\"url\"].isna()]\n",
+    "    df = df[df[\"url\"].apply(check_subdomain)]\n",
+    "    is_image = df[\"url\"].apply(lambda x: checker.has_img_extension(x.rstrip(\"/\"))) | df[\n",
+    "        \"image\"\n",
+    "    ].apply(lambda x: checker.has_img_extension(x.rstrip(\"/\")))\n",
+    "    df = df[is_image]\n",
+    "    if df is None or len(df) == 0:\n",
+    "        continue\n",
+    "    cov_dfs.append(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4ca4fa07-cc87-4480-8e0f-2060168447ab",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_cov_all = pd.concat(cov_dfs)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b2635644-6a17-4671-911e-9324cdcff727",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "display(df_cov_all)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ba475d94-08dd-412b-a0ff-a848327e77e5",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "for x in sorted(df_cov_all.columns):\n",
+    "    print(x)"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
Add a labelled coverage dataset output CSV to the column mapping notebook, which has the same formatting as the unlabelled dataset output but with all the coverage columns included.