### PR TITLE
JNB: Filter out bad core surface images

### DIFF
--- a/notebooks/column_mapping.ipynb
+++ b/notebooks/column_mapping.ipynb
@@ -198,6 +198,49 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "9705a972-2212-47fb-862c-d27cfa8e9298",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load up largest dataset, containing long cruises\n",
+    "df = pd.read_csv(os.path.join(dirname, \"882349.csv\"))\n",
+    "display(df)\n",
+    "print(df.columns)\n",
+    "url_column = find_url_column(df)\n",
+    "print(df[url_column].iloc[0])\n",
+    "print(df[\"dataset_title\"].iloc[0])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "45a8fb82-29d6-4537-aa36-58204ea58870",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2354140a-0c95-42b3-8863-8ceadea95f87",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(12, 8))\n",
+    "plt.plot(-df[\"Depth water\"], label=\"Depth water\")\n",
+    "plt.plot(df[\"Elevation\"], label=\"Elevation\")\n",
+    "plt.legend()\n",
+    "plt.show()\n",
+    "plt.figure(figsize=(12, 8))\n",
+    "plt.plot(df[\"Depth water\"] + df[\"Elevation\"])\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "5bf521eb-f434-47b2-bc07-db240dc34bbb",
    "metadata": {},
    "outputs": [],


### PR DESCRIPTION
It just happens to be that the lower case are extracted, upper case are insitu due to different experimental protocols having different file naming schemes.

Additionally, remove images with "not_available" in the name, since this "image" is just a placeholder image.