### PR TITLE
JNB: More dataset fixes

### DIFF
--- a/notebooks/column_mapping.ipynb
+++ b/notebooks/column_mapping.ipynb
@@ -13,7 +13,9 @@
     "\n",
     "import dateutil.parser\n",
     "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
     "import pandas as pd\n",
+    "from benthicnet.utils import sanitize_filename, sanitize_filename_series\n",
     "from IPython.display import display\n",
     "from tqdm.auto import tqdm\n",
     "\n",
@@ -91,17 +93,24 @@
     "n_total = 0\n",
     "n_valid = 0\n",
     "\n",
+    "verbose = False\n",
+    "\n",
     "for fname in tqdm(os.listdir(dirname)):\n",
     "    ds_id = os.path.splitext(fname)[0]\n",
     "    df = pd.read_csv(os.path.join(dirname, fname))\n",
     "    n_total += 1\n",
+    "\n",
     "    if not checker.has_url_col(df):\n",
     "        continue\n",
+    "\n",
     "    url_col = find_url_column(df)\n",
+    "\n",
     "    if not url_col:\n",
-    "        print(f\"No url column for {fname} with columns\\n{df.columns}\")\n",
+    "        if verbose:\n",
+    "            print(f\"No url column for {fname} with columns\\n{df.columns}\")\n",
     "        files_without_url.append(fname)\n",
     "        continue\n",
+    "\n",
     "    n_valid += 1\n",
     "    for col in df.columns:\n",
     "        col = col.lower().strip()\n",
@@ -388,6 +397,36 @@
     "url_column = find_url_column(df)\n",
     "print(df[url_column].iloc[0])\n",
     "print(df[\"dataset_title\"].iloc[-1])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "db28971c-98c9-4f82-b376-4614d662c190",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = pd.read_csv(os.path.join(dirname, column_examples[\"latitude south\"][0]))\n",
+    "display(df)\n",
+    "print(df.columns)\n",
+    "url_column = find_url_column(df)\n",
+    "print(df[url_column].iloc[0])\n",
+    "print(df[\"dataset_title\"].iloc[0])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1da06fe0-5d27-4161-92ce-817647524b6b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = pd.read_csv(os.path.join(dirname, column_examples[\"date\"][0]))\n",
+    "display(df)\n",
+    "print(df.columns)\n",
+    "url_column = find_url_column(df)\n",
+    "print(df[url_column].iloc[0])\n",
+    "print(df[\"dataset_title\"].iloc[0])"
    ]
   },
   {
@@ -723,6 +762,16 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aeffdb5b-725a-4679-9031-68669e298d21",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "check_title(\"Sea ice conditions at location\")"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "21314a94-a03c-4317-87fb-0578e3f04381",
    "metadata": {},
@@ -752,27 +801,32 @@
     "    n_total += 1\n",
     "    if not checker.has_url_col(df):\n",
     "        continue\n",
-    "    # print(df.columns)\n",
+    "\n",
     "    url_col = find_url_column(df)\n",
     "    if not url_col:\n",
-    "        # print(f\"No url column for {fname} with columns\\n{df.columns}\")\n",
     "        files_without_url.append(fname)\n",
     "        continue\n",
+    "\n",
     "    df[\"ds_id\"] = f\"pangaea-{ds_id}\"\n",
     "    df = reformat_df(df)\n",
     "    if df is None:\n",
     "        continue\n",
+    "    url_col = \"url\"\n",
+    "    df = df[df[url_col] != \"\"]\n",
+    "    if len(df) == 0:\n",
+    "        continue\n",
+    "\n",
     "    n_valid += 1\n",
-    "    dfs.append(df)\n",
-    "    dfs_fnames.append(fname)\n",
+    "\n",
     "    for col in df.columns:\n",
     "        column_count[col] += 1\n",
     "        column_examples[col].append(fname)\n",
-    "    # print(df.columns)\n",
-    "    url_col = \"url\"\n",
-    "    subdf = df[df[url_col] != \"\"]\n",
-    "    if len(subdf) != len(subdf.drop_duplicates(subset=url_col)):\n",
-    "        files_with_repeat_urls.append(fname)"
+    "\n",
+    "    if len(df) != len(df.drop_duplicates(subset=url_col)):\n",
+    "        files_with_repeat_urls.append(fname)\n",
+    "\n",
+    "    dfs.append(df)\n",
+    "    dfs_fnames.append(fname)"
    ]
   },
   {
@@ -785,9 +839,7 @@
    "outputs": [],
    "source": [
     "print(f\"There are {n_valid} valid (of {n_total}) valid datasets\")\n",
-    "print(\n",
-    "    f\"Of which {len(files_with_repeat_urls)} have repeated URLs (possibly multiple annotations)\"\n",
-    ")\n",
+    "print(f\"Of which {len(files_with_repeat_urls)} have repeated URLs\")\n",
     "print()\n",
     "print(f\"There are {len(column_count)} unique column names:\")\n",
     "print()\n",
@@ -911,6 +963,14 @@
    "source": [
     "url_base = unique_url_bases[0]\n",
     "df_all[df_all[\"url\"].str.startswith(url_base)].iloc[[0, -1]]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8d919c8d-136e-4d1f-8275-caf41d17b8b5",
+   "metadata": {},
+   "source": [
+    "### Find bad subdomains"
    ]
   },
   {
@@ -1491,12 +1551,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "60186b43-b1ee-4d82-b208-65ccc793244a",
-   "metadata": {
-    "tags": []
-   },
+   "id": "954df08d-4934-4a40-9268-c26ac162f19c",
+   "metadata": {},
    "source": [
-    "## Save unlabelled dataset"
+    "### Save unlabelled dataset"
    ]
   },
   {
@@ -1514,6 +1572,873 @@
   },
   {
    "cell_type": "markdown",
+   "id": "fd024ef3-6472-4d12-9a87-a75f03a7e54e",
+   "metadata": {},
+   "source": [
+    "### Check images for each title"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "13eb11ae-e912-4f74-a7db-d29188c5db59",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "_dfs = []\n",
+    "_dfs_fnames = []\n",
+    "\n",
+    "for df, df_fname in tqdm(zip(dfs, dfs_fnames), total=len(dfs)):\n",
+    "    url_column = \"url\"\n",
+    "\n",
+    "    # Filter down to only valid URLs\n",
+    "    df = df[df[url_column].apply(checker.is_url)]\n",
+    "    if df is None or len(df) == 0:\n",
+    "        continue\n",
+    "\n",
+    "    # Remove bad subdomains\n",
+    "    df = df[df[url_column].apply(check_subdomain)]\n",
+    "    if df is None or len(df) == 0:\n",
+    "        continue\n",
+    "\n",
+    "    # Filter down to only rows which have image extension\n",
+    "    is_image = df[url_column].apply(lambda x: checker.has_img_extension(x.rstrip(\"/\")))\n",
+    "    if \"image\" in df.columns:\n",
+    "        is_image |= df[\"image\"].apply(\n",
+    "            lambda x: checker.has_img_extension(x.rstrip(\"/\"))\n",
+    "        )\n",
+    "    df = df[is_image]\n",
+    "    if df is None or len(df) == 0:\n",
+    "        continue\n",
+    "\n",
+    "    _dfs.append(df)\n",
+    "    _dfs_fnames.append(df_fname)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "72f3f4ef-e765-4939-8a21-6e6a913fd1e6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"Keeping {len(_dfs)} of {len(dfs)} datasets\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2f782622-6cfd-4744-b19d-5805282fb594",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dfs = _dfs\n",
+    "dfs_fnames = _dfs_fnames"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5e2da16f-0ee4-476d-9de2-a626163d6d59",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "starter_length = 40\n",
+    "title_starters_to_row = {}\n",
+    "\n",
+    "for df, fname in zip(dfs, dfs_fnames):\n",
+    "    if \"dataset_title\" not in df.columns:\n",
+    "        continue\n",
+    "    for title in df[\"dataset_title\"].unique():\n",
+    "        if pd.isna(title):\n",
+    "            continue\n",
+    "        if title[:starter_length] in title_starters_to_row:\n",
+    "            continue\n",
+    "        subdf = df[df[\"dataset_title\"] == title]\n",
+    "        title_starters_to_row[title[:starter_length]] = subdf.iloc[len(subdf) // 2]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "29e4071a-22f2-4c2e-9b4b-dc627b56fb39",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "len(title_starters_to_row)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6fd73eeb-384f-4d0b-8361-124d7b3d5cb7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for k in sorted(title_starters_to_row.keys()):\n",
+    "    print(f\"{k:40} ... {title_starters_to_row[k]['url']}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fa67f17b-d257-4687-b2dc-8237a514cbae",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for k in sorted(title_starters_to_row.keys()):\n",
+    "    print(title_starters_to_row[k][\"dataset_title\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1b297235-d351-456a-8055-735e07e4263c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "unique_url_bases = sorted(\n",
+    "    df_all[\"url\"].apply(lambda x: \"/\".join(x.split(\"/\")[:6])).unique()\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a5dd623d-51c5-4370-afc1-c4ffd1c49c43",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "len(unique_url_bases)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7bcfea66-dc66-4a4d-bd32-a4e5026ed734",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "unique_url_bases = [\n",
+    "    x\n",
+    "    for x in unique_url_bases\n",
+    "    if x.startswith(\"https://hs.pangaea.de/bathy\")\n",
+    "    or x.startswith(\"https://hs.pangaea.de/Images\")\n",
+    "    or x.startswith(\"https://store.pangaea.de/Images\")\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0c8a071c-6b4d-4b60-a38e-acabc3c88c74",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "len(unique_url_bases)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7edde3bf-6fbe-4b3e-8185-1d7c37d99713",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "unique_url_bases\n",
+    "\n",
+    "for i, url_base in enumerate(unique_url_bases):\n",
+    "    print()\n",
+    "    sdf = df_all[df_all[\"url\"].str.startswith(url_base)]\n",
+    "    print(\n",
+    "        \"{:3d}/{} ({:7d} URLs), base {}\".format(\n",
+    "            i + 1, len(unique_url_bases), len(sdf), url_base\n",
+    "        )\n",
+    "    )\n",
+    "    print(sdf[\"url\"].iloc[0])\n",
+    "    if len(sdf) > 2:\n",
+    "        print(sdf[\"url\"].iloc[1])\n",
+    "    if len(sdf) > 4:\n",
+    "        print(sdf[\"url\"].iloc[len(sdf) // 2])\n",
+    "    if len(sdf) > 12:\n",
+    "        print(sdf[\"url\"].iloc[9])\n",
+    "    if len(sdf) > 102:\n",
+    "        print(sdf[\"url\"].iloc[99])\n",
+    "    if len(sdf) > 1002:\n",
+    "        print(sdf[\"url\"].iloc[499])\n",
+    "        print(sdf[\"url\"].iloc[999])\n",
+    "    if len(sdf) > 10002:\n",
+    "        print(sdf[\"url\"].iloc[4999])\n",
+    "        print(sdf[\"url\"].iloc[9999])\n",
+    "    if len(sdf) > 3:\n",
+    "        print(sdf[\"url\"].iloc[-2])\n",
+    "    if len(sdf) > 1:\n",
+    "        print(sdf[\"url\"].iloc[-1])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b3ffaacf-79ed-451b-b567-9c17f72c8c33",
+   "metadata": {},
+   "source": [
+    "#### Refine title and subdomain screening"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fe062b59-e6c0-418c-9a9e-353c2d32aed3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def check_title(title):\n",
+    "    \"\"\"\n",
+    "    Screen dataset title.\n",
+    "\n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    title : str\n",
+    "        The title of the dataset.\n",
+    "\n",
+    "    Returns\n",
+    "    -------\n",
+    "    bool\n",
+    "        Whether the dataset title is acceptable.\n",
+    "    \"\"\"\n",
+    "\n",
+    "    title = str(title)\n",
+    "\n",
+    "    if \"do not use\" in title.lower():\n",
+    "        return False\n",
+    "    if title.startswith(\"Meteorological observations\"):\n",
+    "        return False\n",
+    "    if title.startswith(\"Sea ice conditions\"):\n",
+    "        return False\n",
+    "    if \"topsoil\" in title.lower():\n",
+    "        return False\n",
+    "    if \"core\" in title.lower():\n",
+    "        # return False\n",
+    "        pass\n",
+    "    if \"aquarium\" in title.lower():\n",
+    "        return False\n",
+    "    if \" of the early life history \" in title.lower():\n",
+    "        return False\n",
+    "    if \"grab sample\" in title.lower():\n",
+    "        return False\n",
+    "    if title.startswith(\"Calyx growth\"):\n",
+    "        return False\n",
+    "    if \"dried glass sponges\" in title.lower():\n",
+    "        return False\n",
+    "    if \"fresh glass sponges\" in title.lower():\n",
+    "        return False\n",
+    "    if \"spicule preparations\" in title.lower():\n",
+    "        return False\n",
+    "    if title.startswith(\"Shell growth increments\"):\n",
+    "        return False\n",
+    "    if title.startswith(\"Images of shell cross sections\"):\n",
+    "        return False\n",
+    "\n",
+    "    return True"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "736da96c-e304-4a81-b7f0-34568dca9d07",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "check_title(\"Grab samples from location\")  # Test"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b40c6f49-f76a-4f54-b954-87951802c444",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def check_subdomain(url):\n",
+    "    blacklist = [\n",
+    "        \"https://doi.org/10.1594/PANGAEA\",\n",
+    "        \"http://epic.awi.de/\",\n",
+    "        \"https://epic.awi.de/\",\n",
+    "        \"http://hdl.handle.net/10013/\",\n",
+    "        \"http://library.ucsd.edu/dc/object/\",\n",
+    "        \"https://app.geosamples.org/uploads/UHM/\",\n",
+    "        \"https://hs.pangaea.de/Images/Linescan/\",\n",
+    "        \"https://hs.pangaea.de/Maps/\",\n",
+    "        \"https://hs.pangaea.de//Maps\",\n",
+    "        \"https://hs.pangaea.de/Movies/\",\n",
+    "        \"https://hs.pangaea.de/Projects/\",\n",
+    "        \"https://hs.pangaea.de/bathy/\",\n",
+    "        \"https://hs.pangaea.de/fishsounder/\",\n",
+    "        \"https://hs.pangaea.de/mag/\",\n",
+    "        \"https://hs.pangaea.de/model/\",\n",
+    "        \"https://hs.pangaea.de/nav/\",\n",
+    "        \"https://hs.pangaea.de/palaoa/\",\n",
+    "        \"https://hs.pangaea.de/pasata/\",\n",
+    "        \"https://hs.pangaea.de/para/\",\n",
+    "        \"https://hs.pangaea.de/polar\",\n",
+    "        \"https://hs.pangaea.de/reflec/\",\n",
+    "        \"https://hs.pangaea.de/sat/\",\n",
+    "        \"https://prr.osu.edu/collection/object/\",\n",
+    "        \"https://store.pangaea.de/Projects/\",  # Not all bad, but mostly\n",
+    "        \"https://store.pangaea.de/Publications/\",  # Not all bad, but mostly\n",
+    "        \"https://store.pangaea.de/software/\",\n",
+    "        \"https://www.ngdc.noaa.gov/geosamples/\",\n",
+    "        \"https://hs.pangaea.de/Images/Airphoto/\",\n",
+    "        # \"https://hs.pangaea.de/Images/Cores/\",  # Some of these are okay\n",
+    "        \"https://hs.pangaea.de/Images/Documentation/\",\n",
+    "        \"https://hs.pangaea.de/Images/Maps/\",\n",
+    "        \"https://hs.pangaea.de/Images/MMT/\",\n",
+    "        \"https://hs.pangaea.de/Images/Plankton/\",\n",
+    "        # The GeoB19346-1 dataset contains .bmp images of the ROV's sonar\n",
+    "        \"https://hs.pangaea.de/Images/ROV/M/M114/GeoB19346-1/data_publish/data/sonar/\",\n",
+    "        \"https://hs.pangaea.de/Images/Satellite/\",\n",
+    "        \"https://hs.pangaea.de/Images/SeaIce/\",\n",
+    "        \"https://hs.pangaea.de/Images/Water/\",\n",
+    "        \"https://store.pangaea.de/Images/Airphoto/\",\n",
+    "        \"https://store.pangaea.de/Images/Documentation/\",\n",
+    "        \"https://hs.pangaea.de/Images/Benthos/AWI_experimental_aquarium_system/\",\n",
+    "        # \"https://hs.pangaea.de/Images/Benthos/AntGlassSponges\",  # Only okay if it contains \"AHEAD\"\n",
+    "        \"https://hs.pangaea.de/Images/Benthos/Kongsfjorden/MHerrmann/\",  # Microscope images\n",
+    "        \"https://hs.pangaea.de/Images/Benthos/Kongsfjorden/Brandal/\",  # Cross-sections\n",
+    "    ]\n",
+    "    banned_words = [\n",
+    "        \"aquarium\",\n",
+    "        \"map\",\n",
+    "        \"divemap\",\n",
+    "        \"dredgephotos\",\n",
+    "        \"dredge_photos\",\n",
+    "        \"dredgephotograph\",\n",
+    "        \"grabsample\",\n",
+    "        \"grab_sample\",\n",
+    "    ]\n",
+    "    for entry in blacklist:\n",
+    "        if url.startswith(entry):\n",
+    "            return False\n",
+    "    for word in banned_words:\n",
+    "        if re.search(\"(?<![A-Za-z])\" + word + \"(?![A-Za-z])\", url.lower()):\n",
+    "            return False\n",
+    "    if re.search(\"(?<![a-z])core(?![a-rty])\", url.lower()) and \"SUR\" not in url:\n",
+    "        # Images of cores must contain \"SURFACE\", or the shorthand \"SUR\"\n",
+    "        # We only keep the ones with surface in uppercase, because those\n",
+    "        # experiments are in-situ surface photos, whereas lower case are not.\n",
+    "        return False\n",
+    "    if (\n",
+    "        url.startswith(\"https://hs.pangaea.de/Images/Benthos/AntGlassSponges/\")\n",
+    "        and \"AHEAD\" not in url\n",
+    "    ):\n",
+    "        # Images of AntGlassSponges must contain \"AHEAD\" to be kept\n",
+    "        # otherwise, they are of sponges after removal\n",
+    "        return False\n",
+    "    if \"not_available\" in url:\n",
+    "        return False\n",
+    "    return True"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7ee172d3-7d82-4e12-ab99-5de0f376face",
+   "metadata": {},
+   "source": [
+    "## Load data with URL filtering functions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c9c51ae6-06e3-4807-84dd-57197308e53c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def filter_urls(df, url_column=\"url\", inplace=True):\n",
+    "    if not inplace:\n",
+    "        df = df.copy()\n",
+    "\n",
+    "    if df is None or len(df) == 0:\n",
+    "        return df\n",
+    "\n",
+    "    # Filter down to only valid URLs\n",
+    "    df = df[df[url_column].apply(checker.is_url)]\n",
+    "    if df is None or len(df) == 0:\n",
+    "        return df\n",
+    "\n",
+    "    # Remove bad subdomains\n",
+    "    df = df[df[url_column].apply(check_subdomain)]\n",
+    "    if df is None or len(df) == 0:\n",
+    "        return df\n",
+    "\n",
+    "    # Filter down to only rows which have image extension\n",
+    "    is_image = df[url_column].apply(lambda x: checker.has_img_extension(x.rstrip(\"/\")))\n",
+    "    if \"image\" in df.columns:\n",
+    "        is_image |= df[\"image\"].apply(\n",
+    "            lambda x: checker.has_img_extension(x.rstrip(\"/\"))\n",
+    "        )\n",
+    "    df = df[is_image]\n",
+    "    if df is None or len(df) == 0:\n",
+    "        return df\n",
+    "\n",
+    "    # Drop mosaic images\n",
+    "    df = df[~df[url_column].apply(lambda x: \"mosaic\" in x.lower())]\n",
+    "\n",
+    "    return df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fd4838b1-ddc5-4979-9577-b78b9c72c104",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def fixup_url_with_image(row):\n",
+    "    url_old = row[\"url\"]\n",
+    "    if \"image\" not in row or not row[\"image\"]:\n",
+    "        return url_old\n",
+    "    url = url_old.rstrip(\"/ \")\n",
+    "    url_parts = url.split(\"/\")\n",
+    "    ext = os.path.splitext(url_parts[-1])[-1]\n",
+    "    url_new = \"/\".join(url_parts[:-1])\n",
+    "    if row[\"image\"] + ext == url_parts[-1]:\n",
+    "        return url\n",
+    "    url_new += \"/\" + row[\"image\"]\n",
+    "    return url_new\n",
+    "\n",
+    "\n",
+    "def insert_rows(df, rows, indices):\n",
+    "    parts = [df[: indices[0]], pd.DataFrame([rows[0]])]\n",
+    "    for j in range(len(indices) - 1):\n",
+    "        parts.append(df[indices[j - 1] : indices[j]])\n",
+    "        parts.append(pd.DataFrame([rows[j]]))\n",
+    "    parts.append(df[indices[-1] :])\n",
+    "    return pd.concat(parts)\n",
+    "\n",
+    "\n",
+    "def fixup_repeated_urls(\n",
+    "    df, url_column=\"url\", inplace=True, force_keep_original=True, verbose=1\n",
+    "):\n",
+    "    if not inplace:\n",
+    "        df = df.copy()\n",
+    "    dup_urls = df[df.duplicated(subset=url_column)][url_column].unique()\n",
+    "    if \"image\" not in df.columns:\n",
+    "        if len(dup_urls) and verbose >= 1:\n",
+    "            print(\n",
+    "                f\"Can't clean {len(dup_urls)} repeated URLs in {df.loc[0, 'ds_id']} without 'image' column\"\n",
+    "            )\n",
+    "        return df\n",
+    "    if len(dup_urls) == 0:\n",
+    "        return df\n",
+    "    if verbose >= 1 and \"dataset\" in df.columns:\n",
+    "        print(f\"{df.iloc[0]['dataset']} has {len(dup_urls)} duplicated URLs\")\n",
+    "    rows_to_insert = []\n",
+    "    indices_to_insert_at = []\n",
+    "    for dup_url in dup_urls:\n",
+    "        if pd.isna(dup_url):\n",
+    "            continue\n",
+    "        is_bad_url = df[url_column] == dup_url\n",
+    "        if verbose >= 2:\n",
+    "            n_to_change = sum(is_bad_url)\n",
+    "            print(f\"Fixing up {n_to_change} repetitions of the URL {dup_url}\")\n",
+    "        first_row_idx = np.nonzero(is_bad_url.values)[0][0]\n",
+    "        if force_keep_original:\n",
+    "            # first_row = df[is_bad_url].iloc[0].copy()\n",
+    "            first_row = df.iloc[first_row_idx].copy()\n",
+    "        df.loc[is_bad_url, url_column] = df[is_bad_url].apply(\n",
+    "            fixup_url_with_image, axis=1\n",
+    "        )\n",
+    "        n_remain = sum(df.loc[is_bad_url, url_column] == dup_url)\n",
+    "        if verbose >= 2:\n",
+    "            if n_remain == n_to_change:\n",
+    "                print(f\"  All {n_to_change} URLs left unchanged\")\n",
+    "            else:\n",
+    "                print(f\"  {n_remain} / {n_to_change} URLs remain unchanged\")\n",
+    "                if verbose >= 3:\n",
+    "                    print(\"  After:\")\n",
+    "                    for x in df.loc[is_bad_url, url_column][:5]:\n",
+    "                        print(f\"    {x}\")\n",
+    "                    if n_to_change > 5:\n",
+    "                        print(\"    ...\")\n",
+    "                        print(\"    \" + df.loc[is_bad_url, url_column].values[-1])\n",
+    "\n",
+    "        if force_keep_original and n_remain == 0:\n",
+    "            if verbose >= 1:\n",
+    "                print(f\"  Duplicating a row since the URL {dup_url} no longer appears\")\n",
+    "            first_row[url_column] = dup_url\n",
+    "            rows_to_insert.append(first_row)\n",
+    "            indices_to_insert_at.append(first_row_idx)\n",
+    "    if len(rows_to_insert) > 0:\n",
+    "        if verbose >= 1:\n",
+    "            print(f\"  Inserting {len(rows_to_insert)} duplicated rows\")\n",
+    "        df = insert_rows(df, rows_to_insert, indices_to_insert_at)\n",
+    "    return df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "95630a1b-e47c-40ab-a497-2491fc65e373",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "column_count = defaultdict(lambda: 0)\n",
+    "column_examples = defaultdict(lambda: [])\n",
+    "files_without_url = []\n",
+    "files_with_repeat_urls = []\n",
+    "files_with_repeat_urls2 = []\n",
+    "n_total = 0\n",
+    "n_valid = 0\n",
+    "dfs = []\n",
+    "dfs_fnames = []\n",
+    "\n",
+    "for fname in tqdm(sorted(sorted(os.listdir(dirname)), key=len)):\n",
+    "    # for fname in tqdm(os.listdir(dirname)):\n",
+    "    ds_id = os.path.splitext(fname)[0]\n",
+    "    df = pd.read_csv(os.path.join(dirname, fname))\n",
+    "    n_total += 1\n",
+    "    if not checker.has_url_col(df):\n",
+    "        continue\n",
+    "\n",
+    "    url_col = find_url_column(df)\n",
+    "    if not url_col:\n",
+    "        files_without_url.append(fname)\n",
+    "        continue\n",
+    "\n",
+    "    df[\"ds_id\"] = f\"pangaea-{ds_id}\"\n",
+    "    df = reformat_df(df)\n",
+    "    if df is None:\n",
+    "        continue\n",
+    "\n",
+    "    url_col = \"url\"\n",
+    "    df = df[df[url_col] != \"\"]\n",
+    "    if len(df) == 0:\n",
+    "        continue\n",
+    "\n",
+    "    df = filter_urls(df, url_column=url_col)\n",
+    "    if len(df) == 0:\n",
+    "        continue\n",
+    "\n",
+    "    n_valid += 1\n",
+    "\n",
+    "    for col in df.columns:\n",
+    "        column_count[col] += 1\n",
+    "        column_examples[col].append(fname)\n",
+    "\n",
+    "    # Drop rows that are complete duplicates\n",
+    "    df.drop_duplicates(inplace=True)\n",
+    "\n",
+    "    if len(df) != len(df.drop_duplicates(subset=url_col)):\n",
+    "        files_with_repeat_urls.append(fname)\n",
+    "\n",
+    "    # Try to fix repeated URLs that are accidental dups but should differ\n",
+    "    df = fixup_repeated_urls(df, url_column=url_col, verbose=1)\n",
+    "\n",
+    "    if len(df) != len(df.drop_duplicates(subset=url_col)):\n",
+    "        files_with_repeat_urls2.append(fname)\n",
+    "\n",
+    "    # Check for any rows that are all NaNs\n",
+    "    if sum(df.isna().all(\"columns\")) > 0:\n",
+    "        print(f\"{ds_id} has a row which is all NaNs\")\n",
+    "\n",
+    "    dfs.append(df)\n",
+    "    dfs_fnames.append(fname)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "42118a62-9b2a-4eda-bb37-ee0e805d6f65",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"There are {n_valid} valid (of {n_total}) valid datasets\")\n",
+    "print(\n",
+    "    f\"Of which {len(files_with_repeat_urls)} have repeated URLs (before replacing dups with image)\"\n",
+    ")\n",
+    "print(\n",
+    "    f\"Of which {len(files_with_repeat_urls2)} have repeated URLs (after replacing dups with image)\"\n",
+    ")\n",
+    "print()\n",
+    "print(f\"There are {len(column_count)} unique column names:\")\n",
+    "print()\n",
+    "\n",
+    "for col, count in dict(\n",
+    "    sorted(column_count.items(), key=lambda item: item[1], reverse=True)\n",
+    ").items():\n",
+    "    c = col + \" \"\n",
+    "    print(f\"{c:.<35s} {count:4d}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "29dda41e-720e-43c0-9228-485757b38422",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "select_cols = {\n",
+    "    \"dataset\",\n",
+    "    \"site\",\n",
+    "    \"url\",\n",
+    "    \"image\",\n",
+    "    \"datetime\",\n",
+    "    \"latitude\",\n",
+    "    \"longitude\",\n",
+    "    \"altitude\",\n",
+    "    \"depth\",\n",
+    "    \"backscatter\",\n",
+    "    \"temperature\",\n",
+    "    \"salinity\",\n",
+    "    \"chlorophyll\",\n",
+    "    \"acidity\",\n",
+    "}\n",
+    "\n",
+    "df_all = pd.concat(\n",
+    "    [df[df.columns.intersection(select_cols)] for df in dfs if len(df) > 0]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "53698b76-ae55-4b69-a267-2d3363980f60",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "len(df_all)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "73081233-3c60-44ef-8c7c-a43fb45d2fb5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Remove duplicate URLs\n",
+    "df_all.drop_duplicates(subset=\"url\", inplace=True, keep=\"first\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "55a95594-125b-44ba-9ef9-e1af7d382f9d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_all"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "386bb255-8bd9-48b4-a736-af6d0f67a392",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_all[~df_all[\"url\"].apply(checker.is_url)]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c9339c3c-cb9a-41d4-9615-e87b9418a043",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_all[df_all.isna().all(\"columns\")]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a3a3437d-9a5a-4268-b225-40105f1edac7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "unique_extensions = sorted(\n",
+    "    df_all[\"url\"].apply(lambda x: os.path.splitext(x)[1]).unique()\n",
+    ")\n",
+    "unique_extensions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "66ee5399-a89f-41d8-bf6d-906ccce041ff",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_all[\n",
+    "    df_all[\"url\"]\n",
+    "    == \"https://hs.pangaea.de/Images/Benthos/Great_Barrier_Reef/CCMR/Opal_Reef_2017-01/20170126_Opal_S_C14_289.jpg\"\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2b70dd2a-cfdb-4e50-b56d-41b8ef1ce5c2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_all[\n",
+    "    df_all[\"url\"]\n",
+    "    == \"https://hs.pangaea.de/Images/Benthos/Great_Barrier_Reef/CCMR/Opal_Reef_2017-01/20170126_Opal_DC2-002.jpg\"\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0b7d826e-b94b-4832-9c20-fa3aa0e37f77",
+   "metadata": {},
+   "source": [
+    "### Fix repeated output paths"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "be207e2d-6842-4bc9-bb71-7955b1661ad7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def row2basename(row):\n",
+    "    basename = row[\"image\"]\n",
+    "    if pd.isna(basename) or not basename:\n",
+    "        if pd.isna(row[\"url\"]):\n",
+    "            return \"\"\n",
+    "        basename = row[\"url\"].rstrip(\"/\").split(\"/\")[-1]\n",
+    "    basename = sanitize_filename(basename)\n",
+    "    ext = os.path.splitext(basename)[1]\n",
+    "    expected_ext = os.path.splitext(row[\"url\"].rstrip(\"/\"))[1]\n",
+    "    if expected_ext and ext.lower() != expected_ext.lower():\n",
+    "        if ext.lower() in {\".jpg\", \".jpeg\"}:\n",
+    "            basename = os.path.splitext(basename)[0] + expected_ext\n",
+    "        else:\n",
+    "            basename = basename + expected_ext\n",
+    "    return basename\n",
+    "\n",
+    "\n",
+    "def determine_outpath(df):\n",
+    "    return (\n",
+    "        sanitize_filename_series(df[\"dataset\"])\n",
+    "        + \"/\"\n",
+    "        + sanitize_filename_series(df[\"site\"])\n",
+    "        + \"/\"\n",
+    "        + df.apply(row2basename, axis=1)\n",
+    "    )\n",
+    "\n",
+    "\n",
+    "def fixup_repeated_output_paths(df, inplace=True, verbose=1):\n",
+    "    if not inplace:\n",
+    "        df = df.copy()\n",
+    "    df[\"_outpath\"] = determine_outpath(df)\n",
+    "    dup_outpaths = df[df.duplicated(subset=\"_outpath\")][\"_outpath\"].unique()\n",
+    "\n",
+    "    if len(dup_outpaths) == 0:\n",
+    "        return df\n",
+    "\n",
+    "    if verbose >= 1:\n",
+    "        print(\n",
+    "            f\"There are {len(dup_outpaths)} duplicated output paths in this dataframe\"\n",
+    "        )\n",
+    "\n",
+    "    for dup_outpath in dup_outpaths:\n",
+    "        is_bad = df[\"_outpath\"] == dup_outpath\n",
+    "        n_bad = sum(is_bad)\n",
+    "\n",
+    "        if verbose >= 2:\n",
+    "            print(f\"Trying to fix up {n_bad} repetitions of the path {dup_outpath}\")\n",
+    "\n",
+    "        # 1. Try taking the basename from the URL instead\n",
+    "        # We will try taking just the last bit (photoname.jpg), then including preceding bits\n",
+    "        # of the URL (subsite/photoname.jpg, site/subsite/photoname.jpg)\n",
+    "        subdf = df[is_bad]\n",
+    "        resolved = False\n",
+    "        for k in range(1, 5):\n",
+    "            new_basenames = subdf[\"url\"].apply(\n",
+    "                lambda x: sanitize_filename(\"-\".join(x.rstrip(\"/\").split(\"/\")[-k:]))\n",
+    "            )\n",
+    "            # All URL basenames are unique, so we are done\n",
+    "            if len(new_basenames.unique()) != len(new_basenames):\n",
+    "                continue\n",
+    "            df.loc[is_bad, \"image\"] = new_basenames\n",
+    "            if verbose >= 2:\n",
+    "                print(f\"  Using last {k} part(s) of the URL as the basename\")\n",
+    "            resolved = True\n",
+    "            break\n",
+    "        if resolved:\n",
+    "            continue\n",
+    "\n",
+    "        # 2. If that didn't work, just append _0, _1, ... _N to the image names\n",
+    "        if verbose >= 2:\n",
+    "            print(\"  Appending a suffix to the basename to prevent collisions\")\n",
+    "        new_basenames = subdf.apply(row2basename, axis=1)\n",
+    "        new_basenames = (\n",
+    "            new_basenames.apply(lambda x: os.path.splitext(x)[0])\n",
+    "            + \"_\"\n",
+    "            + pd.Series([str(x) for x in range(n_bad)], index=new_basenames.index)\n",
+    "            + new_basenames.apply(lambda x: os.path.splitext(x)[1])\n",
+    "        )\n",
+    "        df.loc[is_bad, \"image\"] = new_basenames\n",
+    "\n",
+    "    df.drop(columns=\"_outpath\", inplace=True)\n",
+    "    return df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fdcd23ef-9d41-45d2-ba53-1c3899798d83",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "df_all = fixup_repeated_output_paths(df_all, inplace=True, verbose=2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7c167fc-4d45-4323-9ed4-62015ee9c621",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_all"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a2ab29ba-c1b1-4997-b0f9-093553530ab5",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Save unlabelled dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f4cba273-ef16-4bec-bcb0-a83d1882823e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_all.to_csv(\n",
+    "    f\"../pangaea_{datetime.datetime.today().strftime('%Y-%m-%d')}_filtered_no-repeats_sorted-first.csv\",\n",
+    "    index=False,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "53d9f49f-fa72-4175-bd09-231db4f45cf8",
    "metadata": {
     "tags": []
@@ -1525,7 +2450,9 @@
   {
    "cell_type": "markdown",
    "id": "38a26fca-abd4-4cad-8575-dc66b1842ae9",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## Percent Coverage"
    ]
@@ -1533,34 +2460,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b10ff34d-71fa-461b-88b0-be5c1145032f",
+   "id": "c3f3e1c3-7065-428a-b748-68f1ea8e1d94",
    "metadata": {},
    "outputs": [],
    "source": [
-    "cov_dfs = []\n",
-    "for fname in tqdm(coverage_datasets):\n",
-    "    ds_id = os.path.splitext(fname)[0]\n",
-    "    df = pd.read_csv(os.path.join(dirname, fname))\n",
-    "    if not checker.has_url_col(df):\n",
-    "        continue\n",
-    "    # print(df.columns)\n",
-    "    url_col = find_url_column(df)\n",
-    "    if not url_col:\n",
-    "        print(f\"No url column for {fname} with columns\\n{df.columns}\")\n",
-    "        continue\n",
-    "    df[\"ds_id\"] = f\"pangaea-{ds_id}\"\n",
-    "    df = reformat_df(df, remove_duplicate_columns=False)\n",
-    "    if df is None or len(df) == 0:\n",
-    "        continue\n",
-    "    df = df[~df[\"url\"].isna()]\n",
-    "    df = df[df[\"url\"].apply(check_subdomain)]\n",
-    "    is_image = df[\"url\"].apply(lambda x: checker.has_img_extension(x.rstrip(\"/\"))) | df[\n",
-    "        \"image\"\n",
-    "    ].apply(lambda x: checker.has_img_extension(x.rstrip(\"/\")))\n",
-    "    df = df[is_image]\n",
-    "    if df is None or len(df) == 0:\n",
-    "        continue\n",
-    "    cov_dfs.append(df)"
+    "cov_dfs = [dfs[dfs_fnames.index(fname)] for fname in coverage_datasets]"
    ]
   },
   {
@@ -1647,13 +2551,14 @@
     "### Labelled data coverage columns (A) PANGAEA > Roelfsema et. al.\n",
     "\n",
     "Formed from the following 4 dataset \"publication series\":\n",
-    "https://doi.pangaea.de/10.1594/PANGAEA.891711 (CC-BY-3.0)\n",
-    "https://doi.pangaea.de/10.1594/PANGAEA.891736 (CC-BY-3.0)\n",
-    "https://doi.pangaea.de/10.1594/PANGAEA.892623 (CC-BY-3.0)\n",
-    "https://doi.pangaea.de/10.1594/PANGAEA.894801 (CC-BY-4.0)\n",
+    "\n",
+    "    https://doi.pangaea.de/10.1594/PANGAEA.891711 (CC-BY-3.0)\n",
+    "    https://doi.pangaea.de/10.1594/PANGAEA.891736 (CC-BY-3.0)\n",
+    "    https://doi.pangaea.de/10.1594/PANGAEA.892623 (CC-BY-3.0)\n",
+    "    https://doi.pangaea.de/10.1594/PANGAEA.894801 (CC-BY-4.0)\n",
     "\n",
     "All datasets have the same 61 coverage column labels:\n",
-    "```\n",
+    "\n",
     "    Acropora cov\n",
     "    Acropora cov_2\n",
     "    Acroporidae cov\n",
@@ -1715,9 +2620,9 @@
     "    Padina sp. cov\n",
     "    Turbinaria sp. cov\n",
     "    Seagr cov\n",
-    "```\n",
+    "\n",
     "And all have metadata columns:\n",
-    "```\n",
+    "\n",
     "    image\n",
     "    url\n",
     "    latitude\n",
@@ -1729,7 +2634,6 @@
     "    doi\n",
     "    dataset\n",
     "    timestamp\n",
-    "```\n",
     "\n",
     "Note that not all of the labels are manually generated. Abstract for one of them:\n",
     "A subset of photoquadrats were uploaded to the CoralNet machine learning interface (https://coralnet.ucsd.edu/) and manually labelled for coral, algae or substrate type using 50 points per quadrat. Follow training of the machine, this enabled automatic annotation of all unclassified field images: the remaining field photos were uploaded to the database and 50 annotation points were overlaid on each of the images. Every point was assigned a benthic cover category from a label list automatically by the program. The resulting benthic cover data of each photo was linked to gps coordinates, saved as an ArcMap point shapefile, and projected to Universal Transverse Mercator WGS84 Zone 55 South."
@@ -1742,6 +2646,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "column_count_ = defaultdict(lambda: 0)\n",
+    "column_examples_ = defaultdict(lambda: [])\n",
     "files_without_url = []\n",
     "files_with_repeat_urls = []\n",
     "n_total = 0\n",
@@ -1766,6 +2672,11 @@
     "    n_valid += 1\n",
     "    dois.append(df.iloc[0][\"doi\"])\n",
     "    cov_dfs_sub.append(df)\n",
+    "\n",
+    "    for col in df.columns:\n",
+    "        column_count_[col] += 1\n",
+    "        column_examples_[col].append(fname)\n",
+    "\n",
     "    subdf = df[df[url_col] != \"\"]\n",
     "    if len(subdf) != len(subdf.drop_duplicates(subset=url_col)):\n",
     "        files_with_repeat_urls.append(fname)\n",
@@ -1804,11 +2715,11 @@
     "    f\"Of which {len(files_with_repeat_urls)} have repeated URLs (possibly multiple annotations)\"\n",
     ")\n",
     "print()\n",
-    "print(f\"There are {len(column_count)} unique column names:\")\n",
+    "print(f\"There are {len(column_count_)} unique column names:\")\n",
     "print()\n",
     "\n",
     "for col, count in dict(\n",
-    "    sorted(column_count.items(), key=lambda item: item[1], reverse=True)\n",
+    "    sorted(column_count_.items(), key=lambda item: item[1], reverse=True)\n",
     ").items():\n",
     "    if \" cov\" not in col:\n",
     "        pass\n",
@@ -1823,13 +2734,114 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "label_columns = [k for k in column_count_ if \" cov\" in k]\n",
+    "\n",
     "cov_df_sub = pd.concat(cov_dfs_sub)\n",
+    "\n",
+    "print(f\"Number of records: {len(cov_df_sub):6d}  (initial)\")\n",
+    "\n",
+    "cov_df_sub = cov_df_sub[~cov_df_sub[label_columns].isna().all(\"columns\")]\n",
+    "\n",
+    "print(\n",
+    "    f\"Number of records: {len(cov_df_sub):6d}  (remove records where all label columns are NaN)\"\n",
+    ")\n",
+    "\n",
+    "cols_for_dup = list(cov_df_sub.columns)\n",
+    "cols_for_dup.remove(\"dataset\")\n",
+    "cols_for_dup.remove(\"dataset_title\")\n",
+    "cols_for_dup.remove(\"doi\")\n",
+    "cols_for_dup.remove(\"site\")\n",
+    "cols_for_dup.remove(\"image\")\n",
+    "# cols_for_dup.remove(\"Method comm\")\n",
+    "cov_df_sub.drop_duplicates(subset=cols_for_dup, inplace=True)\n",
+    "\n",
+    "print(\n",
+    "    f\"Number of records: {len(cov_df_sub):6d}  (after removing duplicates across datasets)\"\n",
+    ")\n",
+    "print(f\"Number of uq urls: {len(cov_df_sub.drop_duplicates(subset='url')):6d}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ae352046-28b5-4e0f-8f0f-93ecd85af414",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cov_df_sub[cov_df_sub.duplicated(subset=\"url\")][\"dataset\"].unique()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eade0dc3-27cb-4e2f-bff7-c4988919dcfa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cov_df_sub[cov_df_sub.duplicated(subset=\"url\")]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b3c11ebb-91c2-425c-8f0f-9713f9a4cd61",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dup_urls = cov_df_sub[cov_df_sub.duplicated(subset=\"url\")][\"url\"].unique()\n",
+    "\n",
+    "for url in dup_urls:\n",
+    "    print(url, sum(cov_df_sub[\"url\"] == url))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b6916a4e-2146-4a29-ba4d-ffb6e7f06aa1",
+   "metadata": {},
+   "source": [
+    "We found a URL, repeated 1982 times, which was not correct. The correct URLs are as per the image field:\n",
+    "\n",
+    "- URL: https://hs.pangaea.de/Images/Benthos/Great_Barrier_Reef/CCMR/Opal_Reef_2017-01/20170126_Opal_S_C14_289.jpg\n",
+    "- Image: https://hs.pangaea.de/Images/Benthos/Great_Barrier_Reef/CCMR/Opal_Reef_2017-01/20170126_Opal_DC2-002.jpg\n",
+    "\n",
+    "This is now fixed by the ``fixup_repeated_urls`` function."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4b1c7e47-595d-41c7-9bf1-86321e8765cc",
+   "metadata": {},
+   "source": [
+    "We also found one URL which is repeated incorrectly again. The correct URLs are as per the image field:\n",
+    "\n",
+    "- 1: https://hs.pangaea.de/Images/Benthos/Heron_Reef/2018/20181113_Heron_HeronBommie_-001.jpg\n",
+    "- 2: https://hs.pangaea.de/Images/Benthos/Heron_Reef/2018/20181114_Heron_HarrysBommie_-001.jpg"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bea206d2-9a24-4897-9443-f5d96af95cc7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cov_df_sub = fixup_repeated_urls(cov_df_sub)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d02f66ea-c8d1-47f5-8563-f44d84385eeb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"Number of records: {len(cov_df_sub):6d}\")\n",
+    "print(f\"Number of uq urls: {len(cov_df_sub.drop_duplicates(subset='url')):6d}\")\n",
     "\n",
     "cov_df_sub.to_csv(\n",
     "    f\"../pangaea_coverage-a_{datetime.datetime.today().strftime('%Y-%m-%d')}.csv\",\n",
     "    index=False,\n",
     ")\n",
-    "\n",
     "display(cov_df_sub)"
    ]
   },
@@ -1858,6 +2870,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "column_count_ = defaultdict(lambda: 0)\n",
+    "column_examples_ = defaultdict(lambda: [])\n",
     "files_without_url = []\n",
     "files_with_repeat_urls = []\n",
     "n_total = 0\n",
@@ -1882,6 +2896,11 @@
     "    n_valid += 1\n",
     "    dois.append(df.iloc[0][\"doi\"])\n",
     "    cov_dfs_sub.append(df)\n",
+    "\n",
+    "    for col in df.columns:\n",
+    "        column_count_[col] += 1\n",
+    "        column_examples_[col].append(fname)\n",
+    "\n",
     "    subdf = df[df[url_col] != \"\"]\n",
     "    if len(subdf) != len(subdf.drop_duplicates(subset=url_col)):\n",
     "        files_with_repeat_urls.append(fname)\n",
@@ -1918,11 +2937,11 @@
     "    f\"Of which {len(files_with_repeat_urls)} have repeated URLs (possibly multiple annotations)\"\n",
     ")\n",
     "print()\n",
-    "print(f\"There are {len(column_count)} unique column names:\")\n",
+    "print(f\"There are {len(column_count_)} unique column names:\")\n",
     "print()\n",
     "\n",
     "for col, count in dict(\n",
-    "    sorted(column_count.items(), key=lambda item: item[1], reverse=True)\n",
+    "    sorted(column_count_.items(), key=lambda item: item[1], reverse=True)\n",
     ").items():\n",
     "    if \" cov\" not in col:\n",
     "        pass\n",
@@ -1933,11 +2952,116 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "4618b4c6-4389-421b-9da6-cf0a482cdc3d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "label_columns = [k for k in column_count_ if \" cov\" in k]\n",
+    "\n",
+    "cov_df_sub = pd.concat(cov_dfs_sub)\n",
+    "\n",
+    "print(f\"Number of records: {len(cov_df_sub):6d}  (initial)\")\n",
+    "\n",
+    "cov_df_sub = cov_df_sub[~cov_df_sub[label_columns].isna().all(\"columns\")]\n",
+    "\n",
+    "print(\n",
+    "    f\"Number of records: {len(cov_df_sub):6d}  (remove records where all label columns are NaN)\"\n",
+    ")\n",
+    "\n",
+    "cols_for_dup = list(cov_df_sub.columns)\n",
+    "cols_for_dup.remove(\"dataset\")\n",
+    "cols_for_dup.remove(\"dataset_title\")\n",
+    "cols_for_dup.remove(\"doi\")\n",
+    "cols_for_dup.remove(\"site\")\n",
+    "cols_for_dup.remove(\"image\")\n",
+    "# cols_for_dup.remove(\"Method comm\")\n",
+    "cov_df_sub.drop_duplicates(subset=cols_for_dup, inplace=True)\n",
+    "\n",
+    "print(\n",
+    "    f\"Number of records: {len(cov_df_sub):6d}  (after removing duplicates across datasets)\"\n",
+    ")\n",
+    "print(f\"Number of uq urls: {len(cov_df_sub.drop_duplicates(subset='url')):6d}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9c9b52d2-8c0e-4355-8b8b-c7df97f6267b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cov_df_sub[cov_df_sub.duplicated(subset=\"url\")]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9da58c49-e98d-4e57-97cb-2d4689b44ebd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cov_df_sub[cov_df_sub.duplicated(subset=\"url\")].iloc[0][\"url\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d75ab51c-b5fb-49b7-b080-4de3298889b2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cov_df_sub[\n",
+    "    cov_df_sub[\"url\"]\n",
+    "    == \"https://store.pangaea.de/Images/Benthos/EasternBanks/2004-07/2004-07-30_AM3_transect_023.jpg\"\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f93a198d-4ce3-451c-ba52-55b108cd6b93",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for col, vals in cov_df_sub[\n",
+    "    cov_df_sub[\"url\"]\n",
+    "    == \"https://store.pangaea.de/Images/Benthos/EasternBanks/2004-07/2004-07-30_AM3_transect_023.jpg\"\n",
+    "].iteritems():\n",
+    "    if isinstance(vals.iloc[0], str):\n",
+    "        if (vals == vals.iloc[0]).all():\n",
+    "            continue\n",
+    "    else:\n",
+    "        if np.allclose(vals.iloc[0], vals, equal_nan=True):\n",
+    "            continue\n",
+    "\n",
+    "    print(col)\n",
+    "    print(vals)\n",
+    "    print()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7fee4a9b-626b-426c-9502-aed9aadc0d79",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Drop this record, since labels are incompatible\n",
+    "cov_df_sub = cov_df_sub[\n",
+    "    cov_df_sub[\"url\"]\n",
+    "    != \"https://store.pangaea.de/Images/Benthos/EasternBanks/2004-07/2004-07-30_AM3_transect_023.jpg\"\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "ae1904ff-8771-47eb-841f-14746fb0ab64",
    "metadata": {},
    "outputs": [],
    "source": [
-    "cov_df_sub = pd.concat(cov_dfs_sub)\n",
+    "print(f\"Number of records: {len(cov_df_sub):6d}\")\n",
+    "print(f\"Number of uq urls: {len(cov_df_sub.drop_duplicates(subset='url')):6d}\")\n",
     "\n",
     "cov_df_sub.to_csv(\n",
     "    f\"../pangaea_coverage-b_{datetime.datetime.today().strftime('%Y-%m-%d')}.csv\",\n",
@@ -1958,9 +3082,9 @@
     "\n",
     "The rest. 3 datasets in Antarctica, Arctic, and Chile.\n",
     "\n",
-    "https://doi.pangaea.de/10.1594/PANGAEA.839225 (CC-BY-3.0)\n",
-    "https://doi.pangaea.de/10.1594/PANGAEA.841459 (CC-BY-3.0)\n",
-    "https://doi.pangaea.de/10.1594/PANGAEA.897047 (CC-BY-4.0)\n",
+    "    https://doi.pangaea.de/10.1594/PANGAEA.839225 (CC-BY-3.0)\n",
+    "    https://doi.pangaea.de/10.1594/PANGAEA.841459 (CC-BY-3.0)\n",
+    "    https://doi.pangaea.de/10.1594/PANGAEA.897047 (CC-BY-4.0)\n",
     "    https://aslopubs.onlinelibrary.wiley.com/doi/10.1002/lno.11187\n",
     "\n",
     "They are all interested in Bryozoa, but otherwise there isn't any overlap in labels."
@@ -1973,6 +3097,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "column_count_ = defaultdict(lambda: 0)\n",
+    "column_examples_ = defaultdict(lambda: [])\n",
     "files_without_url = []\n",
     "files_with_repeat_urls = []\n",
     "n_total = 0\n",
@@ -1996,7 +3122,13 @@
     "        continue\n",
     "    n_valid += 1\n",
     "    dois.append(df.iloc[0][\"doi\"])\n",
+    "    print(\"{}: {}\".format(df.iloc[0][\"doi\"], len(df)))\n",
     "    cov_dfs_sub.append(df)\n",
+    "\n",
+    "    for col in df.columns:\n",
+    "        column_count_[col] += 1\n",
+    "        column_examples_[col].append(fname)\n",
+    "\n",
     "    subdf = df[df[url_col] != \"\"]\n",
     "    if len(subdf) != len(subdf.drop_duplicates(subset=url_col)):\n",
     "        files_with_repeat_urls.append(fname)\n",
@@ -2009,9 +3141,6 @@
     "                print(c)\n",
     "        first = False\n",
     "    last_df = df\n",
-    "\n",
-    "for doi in sorted(dois):\n",
-    "    print(doi)\n",
     "\n",
     "for c in last_df.columns:\n",
     "    if \" cov\" not in c:\n",
@@ -2033,11 +3162,11 @@
     "    f\"Of which {len(files_with_repeat_urls)} have repeated URLs (possibly multiple annotations)\"\n",
     ")\n",
     "print()\n",
-    "print(f\"There are {len(column_count)} unique column names:\")\n",
+    "print(f\"There are {len(column_count_)} unique column names:\")\n",
     "print()\n",
     "\n",
     "for col, count in dict(\n",
-    "    sorted(column_count.items(), key=lambda item: item[1], reverse=True)\n",
+    "    sorted(column_count_.items(), key=lambda item: item[1], reverse=True)\n",
     ").items():\n",
     "    if \" cov\" not in col:\n",
     "        pass\n",
@@ -2048,18 +3177,175 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fc88f684-7320-4bd4-bd81-b1fc1cb1e2af",
+   "id": "b7207dd3-03be-40db-abe7-472bfdeafd60",
    "metadata": {},
    "outputs": [],
    "source": [
-    "cov_df_sub = pd.concat(cov_dfs_sub)\n",
+    "for cov_df_sub in cov_dfs_sub:\n",
+    "    dataset = cov_df_sub.loc[0, \"dataset\"]\n",
+    "    print()\n",
+    "    print(dataset)\n",
+    "    print()\n",
     "\n",
-    "cov_df_sub.to_csv(\n",
-    "    f\"../pangaea_coverage-c_{datetime.datetime.today().strftime('%Y-%m-%d')}.csv\",\n",
-    "    index=False,\n",
+    "    label_columns = [k for k in cov_df_sub.columns if \" cov\" in k]\n",
+    "\n",
+    "    print(f\"Number of label columns: {len(label_columns)}\")\n",
+    "    print(f\"Number of records: {len(cov_df_sub):6d}  (initial)\")\n",
+    "\n",
+    "    cov_df_sub = cov_df_sub[~cov_df_sub[label_columns].isna().all(\"columns\")]\n",
+    "\n",
+    "    print(\n",
+    "        f\"Number of records: {len(cov_df_sub):6d}  (remove records where all label columns are NaN)\"\n",
+    "    )\n",
+    "\n",
+    "    cols_for_dup = list(cov_df_sub.columns)\n",
+    "    cols_for_dup.remove(\"dataset\")\n",
+    "    cols_for_dup.remove(\"dataset_title\")\n",
+    "    cols_for_dup.remove(\"doi\")\n",
+    "    cols_for_dup.remove(\"site\")\n",
+    "    cols_for_dup.remove(\"image\")\n",
+    "    # cols_for_dup.remove(\"Method comm\")\n",
+    "    cov_df_sub = cov_df_sub.drop_duplicates(subset=cols_for_dup)\n",
+    "\n",
+    "    print(\n",
+    "        f\"Number of records: {len(cov_df_sub):6d}  (after removing duplicates across datasets)\"\n",
+    "    )\n",
+    "    print(f\"Number of uq urls: {len(cov_df_sub.drop_duplicates(subset='url')):6d}\")\n",
+    "\n",
+    "    if len(cov_df_sub) > 1000:\n",
+    "        dsid = dataset.replace(\"pangaea-\", \"\")\n",
+    "        cov_df_sub.to_csv(\n",
+    "            f\"../pangaea_coverage-{dsid}_{datetime.datetime.today().strftime('%Y-%m-%d')}.csv\",\n",
+    "            index=False,\n",
+    "        )\n",
+    "    print()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b22f5dfb-97ea-40fc-b7c1-a34f2e991a9c",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## Additional labels"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a6685770-28b8-4c10-8ff3-163443b08ac3",
+   "metadata": {},
+   "source": [
+    "### Redo column name tally\n",
+    "\n",
+    "But with URLs filtering"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6ac7efb3-0564-4ae9-8888-a93ec824568f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"There are {n_valid} valid (of {n_total}) valid datasets\")\n",
+    "print(\n",
+    "    f\"Of which {len(files_with_repeat_urls)} have repeated URLs (possibly multiple annotations)\"\n",
     ")\n",
+    "print()\n",
+    "print(f\"There are {len(column_count)} unique column names:\")\n",
+    "print()\n",
     "\n",
-    "display(cov_df_sub)"
+    "for col, count in dict(\n",
+    "    sorted(column_count.items(), key=lambda item: item[1], reverse=True)\n",
+    ").items():\n",
+    "    if \" cov\" in col:\n",
+    "        continue\n",
+    "    c = col + \" \"\n",
+    "    print(f\"{c:.<35s} {count:4d}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3290acb6-eaef-404f-bd27-6aca495d1a93",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fname = column_examples[\"Marine litter\"][0]\n",
+    "df = pd.read_csv(os.path.join(dirname, fname))\n",
+    "url_column = find_url_column(df)\n",
+    "print(url_column)\n",
+    "# Remove bad URLs\n",
+    "df = df[df[url_column].apply(checker.is_url)]\n",
+    "display(df)\n",
+    "print(df.columns)\n",
+    "print(df[url_column].iloc[0])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bea6f3b2-529e-4345-94c4-0da418252f90",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df.describe()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5e9a63fd-0f75-41cc-aecb-1aa7a9382724",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fname = column_examples[\"Plank\"][0]\n",
+    "df = pd.read_csv(os.path.join(dirname, fname))\n",
+    "url_column = find_url_column(df)\n",
+    "print(url_column)\n",
+    "# Remove bad URLs\n",
+    "df = df[df[url_column].apply(checker.is_url)]\n",
+    "display(df)\n",
+    "print(df.columns)\n",
+    "print(df[url_column].iloc[0])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b0dcc42d-80f7-46e5-b5f1-977982abd4cc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fname = column_examples[\"Squat lobster\"][0]\n",
+    "df = pd.read_csv(os.path.join(dirname, fname))\n",
+    "url_column = find_url_column(df)\n",
+    "print(url_column)\n",
+    "# Remove bad URLs\n",
+    "df = df[df[url_column].apply(checker.is_url)]\n",
+    "display(df)\n",
+    "print(df.columns)\n",
+    "print(df[url_column].iloc[0])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0c23e3aa-c841-40cb-9494-912c8726db8d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fname = column_examples[\"Hard substrat\"][0]\n",
+    "df = pd.read_csv(os.path.join(dirname, fname))\n",
+    "url_column = find_url_column(df)\n",
+    "print(url_column)\n",
+    "# Remove bad URLs\n",
+    "df = df[df[url_column].apply(checker.is_url)]\n",
+    "display(df)\n",
+    "print(df.columns)\n",
+    "print(df[url_column].iloc[0])\n",
+    "print(df[\"doi\"].iloc[0])"
    ]
   }
  ],


### PR DESCRIPTION
- Fix some records (occurring in labelled coverage data) where the URL was erroneously repeated across the whole dataset. The URLs were corrected by changing the filename at the end of the URL to be the contents of the image field instead, manually verified to be correct URLs.
- Fix repeated output paths, where the same image name is given for multiple different URLs at the same site. These are fixed by taking the preceding bits of the url (e.g. taking "subsite" or "site/subsite" out of a URL structure like "https://.../site/subsite/image.jpg"). [See also https://github.com/DalhousieAI/BenthicNet/pull/23.]
- Remove more bad titles. Found by grouping the titles together and inspecting sample images for leading title strings. (Discovered there were still some to remove when investigating repeated URLs and output paths.)
- Remove more bad subdomains. Found by going through samples from the most prevalent subdomains with an extra level of granularity. e.g. Inspecting https://hs.pangaea.de/Images/Benthos/ at an extra level of detail to find https://hs.pangaea.de/Images/Benthos/AWI_experimental_aquarium_system/ is all no good. (Discovered there were still some to remove when dealing with bad titles.)
- Change timestamp output field to be datetime instead, and include data from the Date field in this, if present. We do not use the Time field because it is time since the experiment began, not time of day.