### PR TITLE
Exploring the meaning the depth column values

### DIFF
--- a/notebooks/explore-altitude-depth-water-columns.ipynb
+++ b/notebooks/explore-altitude-depth-water-columns.ipynb
@@ -41,7 +41,7 @@
    "id": "803f2898-25da-4cea-99fa-3aa74a4f4e3e",
    "metadata": {},
    "source": [
-    "## Load datasets and check distribution of column frequencies"
+    "## 1. Load datasets"
    ]
   },
   {
@@ -57,6 +57,8 @@
     "        ds_id = str(ds_id)\n",
     "    if ds_id.startswith(\"pangaea\"):\n",
     "        ds_id = ds_id.split(\"-\")[-1]\n",
+    "    if ds_id.endswith(\".csv\"):\n",
+    "        ds_id = ds_id.split(\".csv\")[-2]\n",
     "    return f\"https://doi.pangaea.de/10.1594/PANGAEA.{ds_id}\""
    ]
   },
@@ -182,10 +184,25 @@
    "id": "a07b478a-bd3d-417f-8e88-f49ea585c812",
    "metadata": {},
    "source": [
-    "### Examine each of the columns of interest\n",
+    "## 2. Examine each of the columns of interest\n",
     "- Elevation\n",
     "- Depth water\n",
-    "- Altitude"
+    "- Altitude\n",
+    "- Bathy depth\n",
+    "- Depth bot & depth top"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1496287a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Find depth columns\n",
+    "for col in column_examples:\n",
+    "    if \"depth\" in col:\n",
+    "        print(col)"
    ]
   },
   {
@@ -193,7 +210,7 @@
    "id": "f5e1cbe3",
    "metadata": {},
    "source": [
-    "#### Elevation\n",
+    "### 2.1 Elevation\n",
     "**Observations:**\n",
     "- ***Elevation*** values in MOST datasets are negative.\n",
     "- Therefore it is reasonable to assume that ***elevation*** represents the distance of the seafloor from mean sea level.\n",
@@ -226,8 +243,12 @@
     "    url = get_dataset_url(file)\n",
     "    # Show\n",
     "    print(f\"[{i}] Mean: {mean:.2f} ± {sd:.2f} Range: {min_:.2f} to {max_:.2f}\")\n",
+    "    plt.figure(figsize=(16, 4))\n",
+    "    plt.plot(df[key], label=key)\n",
+    "    plt.show()\n",
     "    # Datasets that defy column value norms\n",
     "    if not ((min_ < 0) and (max_ < 0)):\n",
+    "        print(\"\\tDoes not satisfy column value norms.\")\n",
     "        val_exception[url] = (mean, sd, min_, max_)"
    ]
   },
@@ -246,7 +267,7 @@
    "id": "7f68aed3",
    "metadata": {},
    "source": [
-    "#### Depth water\n",
+    "### 2.2 Depth water\n",
     "**Observations:**\n",
     "- ***Depth water*** values in ALL datasets are positive.\n",
     "- Therefore it is reasonable to assume that ***depth water*** represents the absolute distance of the camera vehicle below mean sea level."
@@ -275,8 +296,12 @@
     "    url = get_dataset_url(file)\n",
     "    # Show\n",
     "    print(f\"[{i}] Mean: {mean:.2f} ± {sd:.2f} Range: {min_:.2f} to {max_:.2f}\")\n",
+    "    plt.figure(figsize=(16, 4))\n",
+    "    plt.plot(-df[key], label=key)\n",
+    "    plt.show()\n",
     "    # Datasets that defy column value norms\n",
     "    if (min_ < 0) and (max_ < 0):\n",
+    "        print(\"\\tDoes not satisfy column value norms.\")\n",
     "        val_exception[url] = (mean, sd, min_, max_)"
    ]
   },
@@ -295,7 +320,7 @@
    "id": "9c41f96e",
    "metadata": {},
    "source": [
-    "#### Altitude\n",
+    "### 2.3 Altitude\n",
     "**Observations:**\n",
     "- ***Altitude*** values in MOST (4 of 5) datasets are positive.\n",
     "- Only exception: values negative (probably same as *elevation*)."
@@ -323,8 +348,93 @@
     "    url = get_dataset_url(file)\n",
     "    # Show\n",
     "    print(f\"[{i}] Mean: {mean:.2f} ± {sd:.2f} Range: {min_:.2f} to {max_:.2f}\")\n",
-    "    plt.figure(figsize=(6, 4))\n",
-    "    plt.plot(-df[\"altitude\"], label=\"altitude\")\n",
+    "    plt.figure(figsize=(16, 4))\n",
+    "    plt.plot(-df[key], label=key)\n",
+    "    plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "75247f02",
+   "metadata": {},
+   "source": [
+    "### 2.4 Bathy depth\n",
+    "**Observations:**\n",
+    "- ***Bathy depth*** values in ALL datasets are positive.\n",
+    "- It is reasonable to assume that bathymetry depth refers to the distance from mean sea level to the ocean floor."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a64b6017",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Column to find\n",
+    "key = \"bathy depth\"\n",
+    "\n",
+    "for i, file in enumerate(column_examples[key]):\n",
+    "    df = pd.read_csv(os.path.join(dirname, file))\n",
+    "    url_column = find_url_column(df)\n",
+    "    df.columns = [col.lower() for col in df.columns]\n",
+    "    # Extract info\n",
+    "    mean = df[key].mean()\n",
+    "    sd = df[key].std()\n",
+    "    min_ = df[key].min()\n",
+    "    max_ = df[key].max()\n",
+    "    url = get_dataset_url(file)\n",
+    "    # Show\n",
+    "    print(f\"[{i}] Mean: {mean:.2f} ± {sd:.2f} Range: {min_:.2f} to {max_:.2f}\")\n",
+    "    plt.figure(figsize=(16, 4))\n",
+    "    plt.plot(df[key], label=key)\n",
+    "    plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8a3e13eb",
+   "metadata": {},
+   "source": [
+    "### 2.5 Depth top & depth bot\n",
+    "**Observations:**\n",
+    "- Common sense dictates that ***depth top*** and ***depth bot*** should mean the depth of the top and bottom of the camera vehicle.\n",
+    "- With this assumtion we would expect the difference between top and bot depth to be constant.\n",
+    "- However we can see from the plots that this is rarely the case\n",
+    "- Also, there are instances where the top-bot difference completely overlaps with the top depth."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "836128a0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Column to find\n",
+    "keys = [\"depth top\", \"depth bot\"]\n",
+    "# Depth bot & depth top\n",
+    "\n",
+    "for i, file in enumerate(column_examples[keys[0]]):\n",
+    "    df = pd.read_csv(os.path.join(dirname, file))\n",
+    "    url_column = find_url_column(df)\n",
+    "    df.columns = [col.lower() for col in df.columns]\n",
+    "    for key in keys:\n",
+    "        # Extract info\n",
+    "        mean = df[key].mean()\n",
+    "        sd = df[key].std()\n",
+    "        min_ = df[key].min()\n",
+    "        max_ = df[key].max()\n",
+    "        url = get_dataset_url(file)\n",
+    "        # Show\n",
+    "        print(\n",
+    "            f\"[{i}] '{key}' Mean: {mean:.2f} ± {sd:.2f} Range: {min_:.2f} to {max_:.2f}\"\n",
+    "        )\n",
+    "    plt.figure(figsize=(16, 4))\n",
+    "    for key in keys:\n",
+    "        plt.plot(df[key], label=key)\n",
+    "    plt.plot(abs(df[\"depth top\"] - df[\"depth bot\"]), label=\"diff\", linestyle=\":\")\n",
+    "    plt.legend()\n",
     "    plt.show()"
    ]
   },
@@ -333,7 +443,15 @@
    "id": "83e54609",
    "metadata": {},
    "source": [
-    "## Plot `depth water` and `elevation` values from largest dataset"
+    "## 3. Explore relation between depth columns"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3f1c030f",
+   "metadata": {},
+   "source": [
+    "### 3.1 Plot `depth water` and `elevation` values from largest dataset"
    ]
   },
   {
@@ -359,7 +477,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plt.figure(figsize=(12, 8))\n",
+    "plt.figure(figsize=(16, 8))\n",
     "plt.plot(-df[\"Depth water\"], label=\"Depth water\")\n",
     "plt.plot(df[\"Elevation\"], label=\"Elevation\")\n",
     "plt.legend()\n",
@@ -373,7 +491,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plt.figure(figsize=(12, 8))\n",
+    "plt.figure(figsize=(16, 8))\n",
     "plt.plot(df[\"Depth water\"] + df[\"Elevation\"])\n",
     "plt.show()"
    ]
@@ -383,7 +501,7 @@
    "id": "d1659fa1",
    "metadata": {},
    "source": [
-    "## Datasets with both `depth water` and `elevation` columns"
+    "### 3.2 Datasets with both `depth water` and `elevation` columns"
    ]
   },
   {
@@ -403,7 +521,7 @@
     "\n",
     "for file in intersect:\n",
     "    df = pd.read_csv(os.path.join(dirname, file))\n",
-    "    plt.figure(figsize=(6, 4))\n",
+    "    plt.figure(figsize=(16, 4))\n",
     "    plt.plot(-df[\"Depth water\"], label=\"Depth water\")\n",
     "    plt.plot(df[\"Elevation\"], label=\"Elevation\")\n",
     "    plt.legend()\n",
@@ -415,7 +533,7 @@
    "id": "c5abef93",
    "metadata": {},
    "source": [
-    "## Datasets with both `altitude` and `elevation` columns"
+    "### 3.3 Datasets with both `altitude` and `elevation` columns"
    ]
   },
   {
@@ -437,11 +555,21 @@
     "    df = pd.read_csv(os.path.join(dirname, file))\n",
     "    df.columns = [col.lower() for col in df.columns]\n",
     "    print(\"All values same:\", all(df.altitude == df.elevation))\n",
-    "    plt.figure(figsize=(6, 4))\n",
+    "    plt.figure(figsize=(16, 4))\n",
     "    plt.plot(df[\"altitude\"], label=\"Altitude\")\n",
     "    plt.plot(df[\"elevation\"], label=\"Elevation\")\n",
     "    plt.legend()\n",
     "    plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3c3df991",
+   "metadata": {},
+   "source": [
+    "**Observations:**\n",
+    "- ***Altitude*** values almost completely overlap with elevation (the only discrepancies are because of rounding).\n",
+    "- Therefore it is reasonable to assume that ***Altitude*** and ***Elevation*** mean the same thing."
    ]
   },
   {
@@ -459,7 +587,7 @@
    "id": "ee16e84a",
    "metadata": {},
    "source": [
-    "## Datasets with `altitude`, `depth water` and `elevation` columns"
+    "### 3.4 Datasets with `altitude`, `depth water` and `elevation` columns"
    ]
   },
   {
@@ -477,17 +605,30 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "1496287a",
+   "cell_type": "markdown",
+   "id": "63d81d42",
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "source": [
+    "## 3.5 Datasets with `bathy depth` and `elevation` columns"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "35899785",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bathy_depth_set = set(column_examples[\"bathy_depth\"])\n",
+    "elevation_set = set(column_examples[\"elevation\"])\n",
+    "intersect = elevation_set.intersection(bathy_depth_set)\n",
+    "intersect"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f4a5d7fc",
    "metadata": {},
    "outputs": [],
    "source": []


### PR DESCRIPTION
#### Elevation
- ***Elevation*** values in MOST datasets are negative.
- Therefore it is reasonable to assume that ***elevation*** represents the distance of the seafloor from mean sea level.
- Source may be onboard sensors or previously recorded seafloor elevation data.
- There are a few exceptions (`val_expections`)
    - Positive and zero elevation values don't make sense for underwater photographs
    - These values were probably scraped from the dataset webpage

#### Depth water
- ***Depth water*** values in ALL datasets are positive.
- Therefore it is reasonable to assume that ***depth water*** represents the absolute distance of the camera vehicle below mean sea level.

#### Altitude
- ***Altitude*** values in MOST (4 of 5) datasets are positive.
- Only exception: values negative (probably same as *elevation*).

However, these assumptions are not true in many datasets (evident from the plot of all datasets with both depth water and elevation columns).